### PR TITLE
Add hook for Appmatus CertificateTransparencyTrustManager.checkServerTrusted

### DIFF
--- a/frida-script.js
+++ b/frida-script.js
@@ -510,9 +510,32 @@ setTimeout(function () {
                 console.log('  --> Bypassing Appmattus (Transparency)');
                 return a.proceed(a.request());
             };
-            console.log('[+] Appmattus (Transparency)');
+            console.log('[+] Appmattus (CertificateTransparencyInterceptor)');
         } catch (err) {
-            console.log('[ ] Appmattus (Transparency)');
+            console.log('[ ] Appmattus (CertificateTransparencyInterceptor)');
+        }
+
+        try {
+            const CertificateTransparencyTrustManager = Java.use(
+                'com.appmattus.certificatetransparency.internal.verifier.CertificateTransparencyTrustManager'
+            );
+            CertificateTransparencyTrustManager['checkServerTrusted'].overload(
+                '[Ljava.security.cert.X509Certificate;',
+                'java.lang.String'
+            ).implementation = function (x509CertificateArr, str) {
+                console.log('  --> Bypassing Appmattus (CertificateTransparencyTrustManager)');
+            };
+            CertificateTransparencyTrustManager['checkServerTrusted'].overload(
+                '[Ljava.security.cert.X509Certificate;',
+                'java.lang.String',
+                'java.lang.String'
+            ).implementation = function (x509CertificateArr, str, str2) {
+                console.log('  --> Bypassing Appmattus (CertificateTransparencyTrustManager)');
+                return Java.use('java.util.ArrayList').$new();
+            };
+            console.log('[+] Appmattus (CertificateTransparencyTrustManager)');
+        } catch (err) {
+            console.log('[ ] Appmattus (CertificateTransparencyTrustManager)');
         }
 
         console.log("Unpinning setup completed");


### PR DESCRIPTION
I discovered this method being used in canvasm.myo2, where it blocks traffic to Usercentrics. Traffic without this hook:

![2023-06-23_14-51](https://github.com/httptoolkit/frida-android-unpinning/assets/4048809/de599f92-2216-45fb-9651-1967901445db)

Traffic with this hook:

![2023-06-23_14-50](https://github.com/httptoolkit/frida-android-unpinning/assets/4048809/f48e7737-564c-4c1f-9755-125b9b8aa025)

Thanks for the very helpful [blog post](https://httptoolkit.com/blog/android-reverse-engineering/)! I followed that and documented my process in https://github.com/tweaselORG/meta/issues/31.