### PR TITLE
fix potential null pointer issue to make TikTok works

### DIFF
--- a/native-tls-hook.js
+++ b/native-tls-hook.js
@@ -99,9 +99,9 @@ function patchTargetLib(targetModule, targetName) {
 
     const buildVerificationCallback = (realCallbackAddr) => {
         if (!verificationCallbackCache[realCallbackAddr]) {
-            const realCallback = (!realCallbackAddr || realCallbackAddr.isNull())
-                ? new NativeFunction(realCallbackAddr, 'int', ['pointer','pointer'])
-                : () => SSL_VERIFY_INVALID; // Callback can be null - treat as invalid (=our validation only)
+            const realCallback = (realCallbackAddr && !realCallbackAddr.isNull())
+                ? new NativeFunction(realCallbackAddr, 'int', ['pointer', 'pointer'])
+                : () => SSL_VERIFY_INVALID;
 
             let pendingCheckThreads = new Set();
 


### PR DESCRIPTION
This issue caused the SIGTRAP in TikTok android app. After fixing it, everything is fine.

```
Timestamp: 2025-11-18 18:08:35.286960517+0800
Process uptime: 10s
Cmdline: com.zhiliaoapp.musically
pid: 31902, tid: 32042, name: ChromiumNet0  >>> com.zhiliaoapp.musically <<<
uid: 10197
signal 5 (SIGTRAP), code 1 (TRAP_BRKPT), fault addr 0x0000006ff61c977c
    x0  0000000000000000  x1  0000000000000000  x2  0000000000000000  x3  687474702f312e31
    x4  000000718bdb24f0  x5  687474702f312e31  x6  312e312f70747468  x7  0000006fed641379
    x8  383e811fa5ed2c7e  x9  383e811fa5ed2c7e  x10 0000000000000000  x11 0000000000000000
    x12 000000000000d5f0  x13 0000006fed640f50  x14 0000006fed640ed8  x15 0039a0daafe2fed5
    x16 0000006ff63cec58  x17 000000705f2cef4c  x18 0000000000000000  x19 000000721bd84320
    x20 0000000000000001  x21 0000000000000002  x22 000000721bd84810  x23 0000006fed641690
    x24 0000006fed641560  x25 0000006fed642000  x26 0000000000000000  x27 0000000000000001
```