### PR TITLE
Patch com.android.org.conscrypt.ct.CertificateTransparency->checkCT

### DIFF
--- a/android/android-certificate-unpinning.js
+++ b/android/android-certificate-unpinning.js
@@ -130,6 +130,15 @@ const PINNING_FIXES = {
         }
     ],
 
+    // --- Native Conscrypt CertificateTransparency
+
+    'com.android.org.conscrypt.ct.CertificateTransparency': [
+        {
+            methodName: 'checkCT',
+            replacement: () => NO_OP
+        }
+    ],
+
     // --- Native pinning configuration loading (used for configuration by many libraries)
 
     'android.security.net.config.NetworkSecurityConfig': [


### PR DESCRIPTION
I had this error:

```
 !!! --- Unexpected TLS failure --- !!!
      CertificateException: Certificate chain does not conform to required transparency policy: NOT_ENOUGH_SCTS
      Thrown by com.android.org.conscrypt.ct.CertificateTransparency->checkCT
      [ ] Unrecognized TLS error - this must be patched manually
```

This patch fixes it.