### PR TITLE
Fix native-connect-hook on iOS: resolve libc symbols via global fallback

### DIFF
--- a/native-connect-hook.js
+++ b/native-connect-hook.js
@@ -31,23 +31,22 @@
 
     let fcntl, send, recv, conn;
     try {
-        const systemModule = Process.findModuleByName('libc.so') ?? // Android
-                             Process.findModuleByName('libc.so.6') ?? // Linux
-                             Process.findModuleByName('libsystem_c.dylib'); // iOS
+        const systemModules = [
+            'libc.so',                // Android
+            'libc.so.6',              // Linux
+            'libsystem_c.dylib',      // iOS
+            'libsystem_kernel.dylib' // iOS (syscall wrappers, e.g. fcntl)
+        ].map((name) => Process.findModuleByName(name))
+         .filter((mod) => mod !== null);
 
-        if (!systemModule) throw new Error("Could not find libc or libsystem_c");
+        if (systemModules.length === 0) throw new Error("Could not find any libc/libsystem module");
 
         const resolveExport = (name) => {
-            let addr = systemModule.findExportByName(name);
-            if (addr) return addr;
-            if (typeof Module.getGlobalExportByName === 'function') {
-                try { addr = Module.getGlobalExportByName(name); if (addr) return addr; } catch (_) {}
-            }
-            if (typeof Module.findExportByName === 'function') {
-                addr = Module.findExportByName(null, name);
+            for (const mod of systemModules) {
+                const addr = mod.findExportByName(name);
                 if (addr) return addr;
             }
-            throw new Error(`Could not resolve export '${name}'`);
+            throw new Error(`Could not resolve export '${name}' in system modules`);
         };
 
         fcntl = new NativeFunction(resolveExport('fcntl'), 'int', ['int', 'int', 'int']);

--- a/native-connect-hook.js
+++ b/native-connect-hook.js
@@ -37,11 +37,24 @@
 
         if (!systemModule) throw new Error("Could not find libc or libsystem_c");
 
-        fcntl = new NativeFunction(systemModule.getExportByName('fcntl'), 'int', ['int', 'int', 'int']);
-        send = new NativeFunction(systemModule.getExportByName('send'), 'ssize_t', ['int', 'pointer', 'size_t', 'int']);
-        recv = new NativeFunction(systemModule.getExportByName('recv'), 'ssize_t', ['int', 'pointer', 'size_t', 'int']);
+        const resolveExport = (name) => {
+            let addr = systemModule.findExportByName(name);
+            if (addr) return addr;
+            if (typeof Module.getGlobalExportByName === 'function') {
+                try { addr = Module.getGlobalExportByName(name); if (addr) return addr; } catch (_) {}
+            }
+            if (typeof Module.findExportByName === 'function') {
+                addr = Module.findExportByName(null, name);
+                if (addr) return addr;
+            }
+            throw new Error(`Could not resolve export '${name}'`);
+        };
 
-        conn = systemModule.getExportByName('connect')
+        fcntl = new NativeFunction(resolveExport('fcntl'), 'int', ['int', 'int', 'int']);
+        send = new NativeFunction(resolveExport('send'), 'ssize_t', ['int', 'pointer', 'size_t', 'int']);
+        recv = new NativeFunction(resolveExport('recv'), 'ssize_t', ['int', 'pointer', 'size_t', 'int']);
+
+        conn = resolveExport('connect')
     } catch (e) {
         console.error("Failed to set up native hooks:", e.message);
         console.warn('Could not initialize system functions to to hook raw traffic');


### PR DESCRIPTION
Fixes #223 

**Issue:**

`fcntl` is not exported by `libsystem_c.dylib` on Darwin (it lives in `libsystem_kernel.dylib`), so the setup block threw and aborted all native hooks, leaving `connect()` uninstrumented. Resolve each symbol from the module first, then fall back to a global lookup.

**Fix:**

Added a small resolveExport() helper that resolves each libc symbol from the module first and falls back to a global lookup (Module.getGlobalExportByName / Module.findExportByName(null, …)) when the symbol isn't exported by that specific module. Android/Linux behaviour is unchanged, since those symbols still resolve from libc on the first attempt.